### PR TITLE
Added GitHub Action workflow to build FluidSynth and Libsndfile

### DIFF
--- a/.github/workflows/fluidsynth_libsndfile.yml
+++ b/.github/workflows/fluidsynth_libsndfile.yml
@@ -1,0 +1,26 @@
+name: FluidSynth + Libsndfile
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: FluidSynth + Libsndfile
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build
+      run: ./build.sh
+
+    - name: Create Package
+      run: |
+        mkdir -p package/i686 package/x86_64
+        for arch in i686 x86_64; do
+          cp build/$arch/bin/libfluidsynth*.dll build/$arch/bin/libsndfile*.dll package/$arch
+        done
+
+    - name: Upload Package
+      uses: actions/upload-artifact@v1
+      with:
+        path: package
+        name: fluidsynth_libsndfile

--- a/build.sh
+++ b/build.sh
@@ -275,7 +275,7 @@ launch_container() {
 	if ! docker image inspect "$ImageName" &> /dev/null; then
 		docker build -t "$ImageName" . || return
 	fi
-	docker run --rm -it -v "$(pwd):/src" "$ImageName"
+	docker run --rm -t -v "$(pwd):/src" "$ImageName"
 }
 
 main() {


### PR DESCRIPTION
Removed interactive option when running docker to fix “The input device is not a TTY” error